### PR TITLE
Fixes to session/reader closeAll - not throwing error in parent process when channel list empty

### DIFF
--- a/dom/secureelement/gonk/se_consts.js
+++ b/dom/secureelement/gonk/se_consts.js
@@ -31,6 +31,10 @@ this.MAX_CHANNELS_ALLOWED_PER_SESSION = 4;
 this.TYPE_BASIC_CHANNEL = "basic";
 this.TYPE_LOGICAL_CHANNEL = "logical";
 
+this.OBJ_CHANNEL = "channel";
+this.OBJ_SESSION = "session";
+this.OBJ_READER = "reader";
+
 this.BASIC_CHANNEL = 0;
 
 // According GPCardSpec 2.2


### PR DESCRIPTION
If no channels were previously open session/reader closeAll() was failing with SEGenericError thrown on empty channel list. Test 2-3 was failing because of this bug.
+ empty channel list treated as regular situation
+ refactoring - combined closeChannel, closeAllByReader, closeAllBySession handlers into one method which additionally performs validity checks