### PR TITLE
Revert "Adding dom.secureelement.enabled pref"

### DIFF
--- a/dom/webidl/SecureElement.webidl
+++ b/dom/webidl/SecureElement.webidl
@@ -34,8 +34,7 @@ dictionary SECommand {
                                  // response data or -1 if none is expected
 };
 
-[Pref="dom.secureelement.enabled",
- CheckPermissions="secureelement-manage",
+[CheckPermissions="secureelement-manage",
  AvailableIn="PrivilegedApps",
  JSImplementation="@mozilla.org/secureelement/reader;1"]
 interface SEReader {
@@ -63,8 +62,7 @@ interface SEReader {
   Promise<void> closeAll();
 };
 
-[Pref="dom.secureelement.enabled",
- CheckPermissions="secureelement-manage",
+[CheckPermissions="secureelement-manage",
  AvailableIn="PrivilegedApps",
  JSImplementation="@mozilla.org/secureelement/session;1"]
 interface SESession {
@@ -99,8 +97,7 @@ interface SESession {
   Promise<void> closeAll();
 };
 
-[Pref="dom.secureelement.enabled",
- CheckPermissions="secureelement-manage",
+[CheckPermissions="secureelement-manage",
  AvailableIn="PrivilegedApps",
  JSImplementation="@mozilla.org/secureelement/channel;1"]
 interface SEChannel {
@@ -139,8 +136,7 @@ interface SEChannel {
   Promise<void> close();
 };
 
-[Pref="dom.secureelement.enabled",
- CheckPermissions="secureelement-manage",
+[CheckPermissions="secureelement-manage",
  AvailableIn="PrivilegedApps",
  JSImplementation="@mozilla.org/secureelement/response;1"]
 interface SEResponse {

--- a/dom/webidl/SecureElementManager.webidl
+++ b/dom/webidl/SecureElementManager.webidl
@@ -4,8 +4,7 @@
 
  /* Copyright © 2014 Deutsche Telekom, Inc. */
 
-[Pref="dom.secureelement.enabled",
- CheckPermissions="secureelement-manage",
+[CheckPermissions="secureelement-manage",
  AvailableIn="PrivilegedApps",
  JSImplementation="@mozilla.org/secureelement/manager;1",
  NavigatorProperty="seManager",

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -4275,8 +4275,3 @@ pref("camera.control.low_memory_thresholdMB", 404);
 
 // UDPSocket API
 pref("dom.udpsocket.enabled", false);
-
-// Secure Element API
-#ifdef MOZ_SECUREELEMENT
-pref("dom.secureelement.enabled", true)
-#endif


### PR DESCRIPTION
Reverts svic/SecureElement-v0.1#42, due to missing WebIDL changes